### PR TITLE
Use "tofumatt" instead of Matthew Riley

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@
 
 
 ## People
-- [Matthew Riley](https://github.com/tofumatt)
+- [tofumatt](https://github.com/tofumatt)
 - [Jake Archibald](https://github.com/jakearchibald)
 
 ## Maintained by


### PR DESCRIPTION
Most people just call me this, even in person, so I'd rather that ^_^

Thanks for the listing!
