### PR TITLE
Add Linu.li to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,8 @@ See the [Mozilla MakeDrive Wiki page](https://wiki.mozilla.org/Webmaker/MakeDriv
 
 [Soundslice](https://www.soundslice.com/): Learn and teach music better with interactive notation with [offline mode](https://www.soundslice.com/blog/29/introducing-soundslice-offline-mode/).
 
+[Linu.li](https://linu.li): A privacy-first suite of PDF, image, and developer tools that run entirely client-side using WebAssembly.
+
 ## Who to Follow
 - [Matthew Riley](https://github.com/tofumatt): Works at mozilla, creator of localForage (localstroage, IndexedDb and WebSQL Wrapper)
 - [Jake Archibald](https://github.com/jakearchibald): Self described service worker fanatic, works at google helping make offline web apps a thing.


### PR DESCRIPTION
Hi! I'd like to add **Linu.li** to the Showcase section.

It is an open-source, offline-first PWA that provides PDF manipulation, image compression, and developer tools without server-side processing.

- **Live:** https://linu.li
- **Repo:** https://github.com/immineal/linu-li

I have checked the contribution guidelines and verified the link works. Thanks!